### PR TITLE
Some fixes for session info parsing

### DIFF
--- a/lib/tmux/server.rb
+++ b/lib/tmux/server.rb
@@ -108,7 +108,7 @@ module Tmux
       hash = {}
       output = invoke_command "list-sessions"
       output.each_line do |session|
-        params = session.match(/^(?<name>\w+?): (?<num_windows>\d+) windows \(created (?<creation_time>.+?)\) \[(?<width>\d+)x(?<height>\d+)\](?: \(group (?<group>\d+)\))?(?: \((?<attached>attached)\))?$/)
+        params = session.match(/^(?<name>.?): (?<num_windows>\d+) windows \(created (?<creation_time>.+?)\) \[(?<width>\d+)x(?<height>\d+)\](?: \(group (?<group>\d+)\))?(?: \((?<attached>attached)\))?$/)
 
         name          = params[:name]
         num_windows   = params[:num_windows].to_i

--- a/lib/tmux/server.rb
+++ b/lib/tmux/server.rb
@@ -108,13 +108,14 @@ module Tmux
       hash = {}
       output = invoke_command "list-sessions"
       output.each_line do |session|
-        params = session.match(/^(?<name>\w+?): (?<num_windows>\d+) windows \(created (?<creation_time>.+?)\) \[(?<width>\d+)x(?<height>\d+)\](?: \((?<attached>attached)\))?$/)
+        params = session.match(/^(?<name>\w+?): (?<num_windows>\d+) windows \(created (?<creation_time>.+?)\) \[(?<width>\d+)x(?<height>\d+)\](?: \(group (?<group>\d+)\))?(?: \((?<attached>attached)\))?$/)
 
         name          = params[:name]
         num_windows   = params[:num_windows].to_i
         creation_time = Date.parse(params[:creation_time])
         width         = params[:width].to_i
         height        = params[:height].to_i
+        group         = params[:group].to_i if params[:group]
         attached      = !!params[:attached]
 
         hash[name] = {
@@ -123,6 +124,7 @@ module Tmux
           :creation_time => creation_time,
           :width         => width,
           :height        => height,
+          :group         => group,
           :attached      => attached,
         }
       end

--- a/lib/tmux/server.rb
+++ b/lib/tmux/server.rb
@@ -108,7 +108,7 @@ module Tmux
       hash = {}
       output = invoke_command "list-sessions"
       output.each_line do |session|
-        params = session.match(/^(?<name>.?): (?<num_windows>\d+) windows \(created (?<creation_time>.+?)\) \[(?<width>\d+)x(?<height>\d+)\](?: \(group (?<group>\d+)\))?(?: \((?<attached>attached)\))?$/)
+        params = session.match(/^(?<name>.+?): (?<num_windows>\d+) windows \(created (?<creation_time>.+?)\) \[(?<width>\d+)x(?<height>\d+)\](?: \(group (?<group>\d+)\))?(?: \((?<attached>attached)\))?$/)
 
         name          = params[:name]
         num_windows   = params[:num_windows].to_i

--- a/lib/tmux/session.rb
+++ b/lib/tmux/session.rb
@@ -191,6 +191,13 @@ module Tmux
     end
     alias_method :attached?, :attached
 
+    # @return [Integer]
+    attr_reader :group
+    undef_method "group"
+    def group
+      @server.sessions_information[@name][:group]
+    end
+
     # @return [Array<Client>] All {Client clients}
     attr_reader :clients
     undef_method "clients"


### PR DESCRIPTION
tmux-ruby crashed whenever it tried to get info about grouped sessions. Here's a quick fix. More generic grouping support is needed?

tmux session name can contain any characters as fas as I can tell.
